### PR TITLE
[FPGA] Adding sim targets to loop_fusion & optimize_inner_loop

### DIFF
--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/optimize_inner_loop/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/optimize_inner_loop/README.md
@@ -162,6 +162,10 @@ To learn more about the extensions and how to configure the oneAPI environment, 
      ```
      make report
      ```
+   * Compile for simulation (fast compile time, targets simulated FPGA device, reduced data size):
+     ```
+     make fpga_sim
+     ```
    * Compile for FPGA hardware (longer compile time, targets FPGA device):
      ```
      make fpga
@@ -198,6 +202,10 @@ To learn more about the extensions and how to configure the oneAPI environment, 
    * Generate the optimization report:
      ```
      nmake report
+     ```
+   * Compile for simulation (fast compile time, targets simulated FPGA device, reduced data size):
+     ```
+     nmake fpga_sim
      ```
    * Compile for FPGA hardware (longer compile time, targets FPGA device):
      ```
@@ -241,7 +249,12 @@ Version 2 of the kernel (`Producer<2>`) explicitly bounds the inner loop trip co
      ./optimize_inner_loop.fpga_emu    (Linux)
      optimize_inner_loop.fpga_emu.exe  (Windows)
      ```
-2. Run the sample on the FPGA device:
+2. Run the sample on the FPGA simulator device:
+     ```
+     ./loop_carried_dependency.fpga_sim     (Linux)
+     loop_carried_dependency.fpga_sim.exe   (Windows)
+     ```
+3. Run the sample on the FPGA device:
      ```
      ./optimize_inner_loop.fpga        (Linux)
      optimize_inner_loop.fpga.exe      (Windows)
@@ -250,7 +263,7 @@ Version 2 of the kernel (`Producer<2>`) explicitly bounds the inner loop trip co
 ### Example of Output
 You should see the following output in the console:
 
-1. When running on the FPGA emulator
+1. When running on the FPGA emulator or simulator
     ```
     generating 5000 random numbers in the range [0,3)
     Running kernel 0

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/optimize_inner_loop/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/optimize_inner_loop/src/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(SOURCE_FILE optimize_inner_loop.cpp)
 set(TARGET_NAME optimize_inner_loop)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)
+set(SIMULATOR_TARGET ${TARGET_NAME}.fpga_sim)
 set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
@@ -22,6 +23,9 @@ endif()
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.
 set(EMULATOR_COMPILE_FLAGS "-Wall -fintelfpga -DFPGA_EMULATOR")
 set(EMULATOR_LINK_FLAGS "-fintelfpga")
+set(SIMULATOR_COMPILE_FLAGS "-Wall -fintelfpga -Xssimulation -DFPGA_SIMULATOR ${USER_SIMULATOR_FLAGS}")
+set(SIMULATOR_LINK_FLAGS "-fintelfpga -Xssimulation -Xstarget=${FPGA_DEVICE} ${USER_SIMULATOR_FLAGS}")
+# use cmake -D USER_SIMULATOR_FLAGS=<flags> to set extra flags for FPGA simulator compilation
 set(HARDWARE_COMPILE_FLAGS "-Wall -fintelfpga")
 set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xstarget=${FPGA_DEVICE} ${USER_HARDWARE_FLAGS}")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
@@ -39,6 +43,19 @@ target_include_directories(${EMULATOR_TARGET} PRIVATE ../../../../include)
 set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${EMULATOR_COMPILE_FLAGS}")
 set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS "${EMULATOR_LINK_FLAGS}")
 add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
+###############################################################################
+### FPGA Simulator
+###############################################################################
+# To compile in a single command:
+#    dpcpp -fintelfpga -Xssimulation -Xstarget=<FPGA_DEVICE> -DFPGA_SIMULATOR loop_carried_dependency.cpp -o loop_carried_dependency.fpga_sim
+# CMake executes:
+#    [compile] dpcpp -fintelfpga -Xssimulation -DFPGA_SIMULATOR -o loop_carried_dependency.cpp.o -c loop_carried_dependency.cpp
+#    [link]    dpcpp -fintelfpga -Xssimulation -Xstarget=<FPGA_DEVICE> loop_carried_dependency.cpp.o -o loop_carried_dependency.fpga_sim
+add_executable(${SIMULATOR_TARGET} ${SOURCE_FILE})
+target_include_directories(${SIMULATOR_TARGET} PRIVATE ../../../../include)
+set_target_properties(${SIMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${SIMULATOR_COMPILE_FLAGS}")
+set_target_properties(${SIMULATOR_TARGET} PROPERTIES LINK_FLAGS "${SIMULATOR_LINK_FLAGS}")
+add_custom_target(fpga_sim DEPENDS ${SIMULATOR_TARGET})
 
 ###############################################################################
 ### Generate Report

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/optimize_inner_loop/src/optimize_inner_loop.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/optimize_inner_loop/src/optimize_inner_loop.cpp
@@ -172,12 +172,14 @@ int main(int argc, char *argv[]) {
   // the device selector
 #if defined(FPGA_EMULATOR)
   ext::intel::fpga_emulator_selector selector;
+#elif defined(FPGA_SIMULATOR)
+  ext::intel::fpga_simulator_selector selector;
 #else
   ext::intel::fpga_selector selector;
 #endif
 
   // set the input size based on whether we are in emulation or FPGA hardware
-#if defined(FPGA_EMULATOR)
+#if defined(FPGA_EMULATOR) || defined(FPGA_SIMULATOR)
   int size = 5000;
 #else
   int size = 5000000;
@@ -258,7 +260,7 @@ int main(int argc, char *argv[]) {
   if (success) {
     // the emulator does not accurately represent real hardware performance.
     // Therefore, we don't show performance results when running in emulation.
-#if !defined(FPGA_EMULATOR)
+#if !defined(FPGA_EMULATOR) && !defined(FPGA_SIMULATOR)
     double input_size_bytes = size * sizeof(int);
 
     // only display two decimal points

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_fusion/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_fusion/README.md
@@ -138,6 +138,10 @@ To learn more about the extensions and how to configure the oneAPI environment, 
      ```
      make report
      ```
+   * Compile for simulation (fast compile time, targets simulated FPGA device, reduced data size):
+     ```
+     make fpga_sim
+     ```
    * Compile for FPGA hardware (longer compile time, targets FPGA device):
      ```
      make fpga
@@ -175,6 +179,10 @@ To learn more about the extensions and how to configure the oneAPI environment, 
      ```
      nmake report
      ```
+   * Compile for simulation (fast compile time, targets simulated FPGA device, reduced data size):
+     ```
+     nmake fpga_sim
+     ```
    * Compile for FPGA hardware (longer compile time, targets FPGA device):
      ```
      nmake fpga
@@ -209,12 +217,17 @@ Navigate to the Area Analysis of the system under Area Analysis. The Kernel Syst
 
 ## Running the Sample
 
- 1. Run the sample on the FPGA emulator (the kernel executes on the CPU):
+1. Run the sample on the FPGA emulator (the kernel executes on the CPU):
      ```
      ./loop_fusion.fpga_emu     (Linux)
      loop_fusion.fpga_emu.exe   (Windows)
      ```
-2. Run the sample on the FPGA device:
+2. Run the sample on the FPGA simulator device:
+     ```
+     ./loop_fusion.fpga_sim     (Linux)
+     loop_fusion.fpga_sim.exe   (Windows)
+     ```
+3. Run the sample on the FPGA device:
      ```
      ./loop_fusion.fpga         (Linux)
      loop_fusion.fpga.exe       (Windows)
@@ -234,7 +247,7 @@ PASSED: The results are correct
 
 Loop fusion increases the throughput by ~100% in both the cases with equally-sized and unequally-sized loops.
 
-> **Note**: This performance difference will be apparent only when running on FPGA hardware. The emulator, while useful for verifying functionality, will generally not reflect differences in performance.
+> **Note**: This performance difference will be apparent only when running on FPGA hardware. The emulator and simulator, while useful for verifying functionality, will generally not reflect differences in performance.
 
 ## License
 Code samples are licensed under the MIT license. See

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_fusion/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_fusion/src/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(SOURCE_FILE loop_fusion.cpp)
 set(TARGET_NAME loop_fusion)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)
+set(SIMULATOR_TARGET ${TARGET_NAME}.fpga_sim)
 set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
@@ -22,6 +23,9 @@ endif()
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.
 set(EMULATOR_COMPILE_FLAGS "-Wall -fintelfpga -DFPGA_EMULATOR")
 set(EMULATOR_LINK_FLAGS "-fintelfpga")
+set(SIMULATOR_COMPILE_FLAGS "-Wall -fintelfpga -Xssimulation -DFPGA_SIMULATOR ${USER_SIMULATOR_FLAGS}")
+set(SIMULATOR_LINK_FLAGS "-fintelfpga -Xssimulation -Xstarget=${FPGA_DEVICE} ${USER_SIMULATOR_FLAGS}")
+# use cmake -D USER_SIMULATOR_FLAGS=<flags> to set extra flags for FPGA simulator compilation
 set(HARDWARE_COMPILE_FLAGS "-Wall -fintelfpga")
 set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xstarget=${FPGA_DEVICE} ${USER_HARDWARE_FLAGS}")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
@@ -39,6 +43,19 @@ target_include_directories(${EMULATOR_TARGET} PRIVATE ../../../../include)
 set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${EMULATOR_COMPILE_FLAGS}")
 set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS "${EMULATOR_LINK_FLAGS}")
 add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
+###############################################################################
+### FPGA Simulator
+###############################################################################
+# To compile in a single command:
+#    dpcpp -fintelfpga -Xssimulation -Xstarget=<FPGA_DEVICE> -DFPGA_SIMULATOR loop_carried_dependency.cpp -o loop_carried_dependency.fpga_sim
+# CMake executes:
+#    [compile] dpcpp -fintelfpga -Xssimulation -DFPGA_SIMULATOR -o loop_carried_dependency.cpp.o -c loop_carried_dependency.cpp
+#    [link]    dpcpp -fintelfpga -Xssimulation -Xstarget=<FPGA_DEVICE> loop_carried_dependency.cpp.o -o loop_carried_dependency.fpga_sim
+add_executable(${SIMULATOR_TARGET} ${SOURCE_FILE})
+target_include_directories(${SIMULATOR_TARGET} PRIVATE ../../../../include)
+set_target_properties(${SIMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${SIMULATOR_COMPILE_FLAGS}")
+set_target_properties(${SIMULATOR_TARGET} PROPERTIES LINK_FLAGS "${SIMULATOR_LINK_FLAGS}")
+add_custom_target(fpga_sim DEPENDS ${SIMULATOR_TARGET})
 
 ###############################################################################
 ### Generate Report

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_fusion/src/loop_fusion.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_fusion/src/loop_fusion.cpp
@@ -3,14 +3,18 @@
 //
 // SPDX-License-Identifier: MIT
 // =============================================================
-#include <sycl/sycl.hpp>
 #include <iomanip>
 #include <iostream>
 #include <sycl/ext/intel/fpga_extensions.hpp>
+#include <sycl/sycl.hpp>
 
 #include "exception_handler.hpp"
 
+#if defined(FPGA_SIMULATOR)
+constexpr size_t kTripCount{100};
+#else
 constexpr size_t kTripCount{10000000};
+#endif
 constexpr size_t kDifferentTripCount{kTripCount + 1};
 constexpr size_t kArraySize{100};
 
@@ -27,6 +31,8 @@ class FusionFunctionKernel;
 
 #if defined(FPGA_EMULATOR)
 ext::intel::fpga_emulator_selector selector;
+#elif defined(FPGA_SIMULATOR)
+ext::intel::fpga_simulator_selector selector;
 #else
 ext::intel::fpga_selector selector;
 #endif


### PR DESCRIPTION
Add support for the FPGA simulator to run the code samples for loop_carried_dependency, triangular_loop, stall_enable

Uses ext::intel::fpga_simulator_selector class to choose the simulator.

# Existing Sample Changes

DirectProgramming/DPC++FPGA/Tutorials/Features/loop_fusion
DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/optimize_inner_loop

## Description

Add support for running these code samples on the FPGA simulator. Reduced data sizes to ensure reasonable execution times, as simulator is 1000-10000x slower than hardware

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

This has been run manually on Linux and Windows. I am in the process of running through the regtest infra, and will not submit until that is done.

Regtest in Linux: https://spetc.intel.com/testsummary?trview=5&runBy=11136&runBy_reporting_eng=true&testRunIds=7055919
Awaiting windows
Awaiting Windows regtest....

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used