### PR TITLE
ANR Clang format

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/anr/src/anr_params.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/anr/src/anr_params.hpp
@@ -1,11 +1,11 @@
 #ifndef __ANR_PARAMS_HPP__
 #define __ANR_PARAMS_HPP__
 
-#include <sycl/sycl.hpp>
-#include <sycl/ext/intel/fpga_extensions.hpp>
-#include <sycl/ext/intel/ac_types/ac_fixed.hpp>
 #include <iostream>
 #include <string>
+#include <sycl/ext/intel/ac_types/ac_fixed.hpp>
+#include <sycl/ext/intel/fpga_extensions.hpp>
+#include <sycl/sycl.hpp>
 #include <utility>
 
 //

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/anr/src/column_stencil.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/anr/src/column_stencil.hpp
@@ -1,8 +1,8 @@
 #ifndef __COLUMN_STENCIL_HPP__
 #define __COLUMN_STENCIL_HPP__
 
-#include <sycl/sycl.hpp>
 #include <sycl/ext/intel/fpga_extensions.hpp>
+#include <sycl/sycl.hpp>
 
 #include "data_bundle.hpp"
 #include "shift_reg.hpp"
@@ -103,7 +103,7 @@ void ColumnStencil(IndexT rows, IndexT cols, const InType zero_val,
   fpga_tools::ShiftReg2d<InType, kShiftRegRows, kShiftRegCols> shifty_2d;
 
   // the line buffer fifo
-  [[intel::fpga_memory]]
+  [[intel::fpga_memory]]  // NO-FORMAT: Attribute
   InPipeT line_buffer_FIFO[kLineBufferFIFODepth][kNumLineBuffers];
 
   InPipeT last_new_pixels(zero_val);
@@ -115,9 +115,10 @@ void ColumnStencil(IndexT rows, IndexT cols, const InType zero_val,
   // small number relative padded_rows * col_loop_bound and the
   // increase in Fmax justifies it.
   [[intel::loop_coalesce(2), intel::initiation_interval(1),
-    intel::ivdep(line_buffer_FIFO)]]
-  for (IndexT row = 0; row < padded_rows; row++) {
-    [[intel::initiation_interval(1), intel::ivdep(line_buffer_FIFO)]]
+    intel::ivdep(line_buffer_FIFO)]] for (IndexT row = 0; row < padded_rows;
+                                          row++) {
+    [[intel::initiation_interval(1),
+      intel::ivdep(line_buffer_FIFO)]]  // NO-FORMAT: Attribute
     for (IndexT col_loop = 0; col_loop < col_loop_bound; col_loop++) {
       // the base column index for this iteration
       IndexT col = col_loop * parallel_cols;
@@ -136,7 +137,7 @@ void ColumnStencil(IndexT rows, IndexT cols, const InType zero_val,
       input_val.template ShiftMultiVals<kInputShiftVals, parallel_cols>(
           new_pixels);
 
-      [[intel::fpga_register]]
+      [[intel::fpga_register]]  // NO-FORMAT: Attribute
       InPipeT pixel_column[filter_size];
 
       // load from FIFO to shift register
@@ -190,7 +191,7 @@ void ColumnStencil(IndexT rows, IndexT cols, const InType zero_val,
 
         // pass a copy of the line buffer's register window.
         out_data[stencil_idx] = func((row - kRowOutputThreshLow), col_local,
-                                      shifty_copy, stencil_args...);
+                                     shifty_copy, stencil_args...);
       });
 
       // write the output data if it is in range (i.e., it is a real pixel

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/anr/src/constants.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/anr/src/constants.hpp
@@ -23,7 +23,7 @@ static_assert(fpga_tools::IsPow2(kPixelsPerCycle) > 0);
 
 // The maximum number of columns in the image
 #ifndef MAX_COLS
-#define MAX_COLS 1920 // HD
+#define MAX_COLS 1920  // HD
 //#define MAX_COLS 3840  // 4K
 //#define MAX_COLS 2048
 #endif
@@ -39,19 +39,19 @@ constexpr unsigned kMaxRows = MAX_ROWS;
 static_assert(kMaxRows > 0);
 
 // pick the indexing variable size based on kMaxCols and kMaxRows
-constexpr unsigned kSmallIndexTBits =
-    fpga_tools::Max(fpga_tools::CeilLog2(kMaxCols),
-                    fpga_tools::CeilLog2(kMaxRows));
+constexpr unsigned kSmallIndexTBits = fpga_tools::Max(
+    fpga_tools::CeilLog2(kMaxCols), fpga_tools::CeilLog2(kMaxRows));
 using SmallIndexT = ac_int<kSmallIndexTBits, false>;
 
 // add max() function to std::numeric_limits for IndexT
 namespace std {
-  template<> class numeric_limits<SmallIndexT> {
-  public:
-    static constexpr int max() { return (1 << kSmallIndexTBits) - 1; };
-    static constexpr int min() { return 0; };
-  };
+template <>
+class numeric_limits<SmallIndexT> {
+ public:
+  static constexpr int max() { return (1 << kSmallIndexTBits) - 1; };
+  static constexpr int min() { return 0; };
 };
+};  // namespace std
 
 // the type used for indexing the rows and columns of the image
 using IndexT = short;
@@ -68,20 +68,21 @@ static_assert(kPixelBits > 0);
 // the type to use for the pixel intensity values and a temporary type
 // which should have more bits than the pixel type to check for overflow.
 // We will use subtraction on the temporary type, so it must be signed.
-using PixelT = ac_int<kPixelBits, false>; // 'kPixelBits' bits, unsigned
-using TmpT = long long;                   // 64 bits, signed
+using PixelT = ac_int<kPixelBits, false>;  // 'kPixelBits' bits, unsigned
+using TmpT = long long;                    // 64 bits, signed
 constexpr int kPixelRange = (1 << kPixelBits);
 static_assert(std::is_signed_v<TmpT>);
 static_assert((sizeof(TmpT) * 8) > kPixelBits);
 
 // add min() and max() functions to std::numeric_limits for PixelT
 namespace std {
-  template<> class numeric_limits<PixelT> {
-  public:
-    static constexpr int max() { return (1 << kPixelBits) - 1; };
-    static constexpr int min() { return 0; };
-  };
+template <>
+class numeric_limits<PixelT> {
+ public:
+  static constexpr int max() { return (1 << kPixelBits) - 1; };
+  static constexpr int min() { return 0; };
 };
+};  // namespace std
 
 // PSRN default threshold
 // https://en.wikipedia.org/wiki/Peak_signal-to-noise_ratio

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/anr/src/intensity_sigma_lut.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/anr/src/intensity_sigma_lut.hpp
@@ -1,8 +1,8 @@
 #ifndef __INTENSITY_SIGMA_LUT_HPP__
 #define __INTENSITY_SIGMA_LUT_HPP__
 
-#include <sycl/sycl.hpp>
 #include <sycl/ext/intel/fpga_extensions.hpp>
+#include <sycl/sycl.hpp>
 #include <type_traits>
 
 #include "anr_params.hpp"
@@ -16,7 +16,7 @@ class IntensitySigmaLUT {
   // default constructor
   IntensitySigmaLUT() {}
 
-#if defined (IS_BSP)
+#if defined(IS_BSP)
   // construct from a device_ptr (for constructing from device memory)
   IntensitySigmaLUT(device_ptr<float> ptr) {
     // use a pipelined LSU to load from device memory since we don't
@@ -26,7 +26,7 @@ class IntensitySigmaLUT {
       data_[i] = PipelinedLSU::load(ptr + i);
     }
   }
-#else 
+#else
   // construct from a regular pointer
   IntensitySigmaLUT(float* ptr) {
     for (int i = 0; i < lut_depth; i++) {
@@ -49,11 +49,11 @@ class IntensitySigmaLUT {
 
   // helper static method to allocate enough memory to hold the LUT
   static float* Allocate(sycl::queue& q) {
-#if defined (IS_BSP)
+#if defined(IS_BSP)
     float* ptr = sycl::malloc_device<float>(lut_depth, q);
-#else 
+#else
     float* ptr = sycl::malloc_shared<float>(lut_depth, q);
-#endif   
+#endif
     if (ptr == nullptr) {
       std::cerr << "ERROR: could not allocate space for 'ptr'\n";
       std::terminate();

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/anr/src/qfp.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/anr/src/qfp.hpp
@@ -23,12 +23,12 @@ struct QFP {
   // determine if the QFP can fit into a unsigned char or unsigned short (if
   // not, default to an unsigned int)
   static constexpr bool fits_in_uchar =
-    qfp_total_bits <= sizeof(unsigned char)*8;
+      qfp_total_bits <= sizeof(unsigned char) * 8;
   static constexpr bool fits_in_ushort =
-    qfp_total_bits <= sizeof(unsigned short)*8;
-  
-  using qfp_type =
-    std::conditional_t<fits_in_uchar, unsigned char,
+      qfp_total_bits <= sizeof(unsigned short) * 8;
+
+  using qfp_type = std::conditional_t<
+      fits_in_uchar, unsigned char,
       std::conditional_t<fits_in_ushort, unsigned short, unsigned>>;
 
   // 32-bit floating point bits based on
@@ -38,8 +38,7 @@ struct QFP {
   static constexpr unsigned kFP32MantissaBits = 23;
   static constexpr unsigned kFP32TotalBits =
       kFP32SignBits + kFP32ExponentBits + kFP32MantissaBits;
-  static constexpr int kFP32ExponentOffset =
-    (1 << (kFP32ExponentBits-1)) - 1;
+  static constexpr int kFP32ExponentOffset = (1 << (kFP32ExponentBits - 1)) - 1;
   static constexpr unsigned kFP32ExponentMask = (1 << kFP32ExponentBits) - 1;
   static constexpr unsigned kFP32MantissaMask = (1 << kFP32MantissaBits) - 1;
 
@@ -47,9 +46,9 @@ struct QFP {
   typedef union {
     float f;
     struct {
-      unsigned mantissa   : kFP32MantissaBits;
-      unsigned exponent   : kFP32ExponentBits;
-      unsigned sign       : kFP32SignBits;
+      unsigned mantissa : kFP32MantissaBits;
+      unsigned exponent : kFP32ExponentBits;
+      unsigned sign : kFP32SignBits;
     } parts;
   } FloatCast;
 
@@ -61,8 +60,7 @@ struct QFP {
   static constexpr unsigned qfp_mask = (1 << qfp_total_bits) - 1;
   static constexpr unsigned qfp_exponent_mask = (1 << qfp_exponent_bits) - 1;
   static constexpr unsigned qfp_mantissa_mask = (1 << qfp_mantissa_bits) - 1;
-  static constexpr int qfp_exponent_offset =
-      (1 << (qfp_exponent_bits - 1)) - 1;
+  static constexpr int qfp_exponent_offset = (1 << (qfp_exponent_bits - 1)) - 1;
 
   // the difference in bits between the QFP and the 32-bit float
   static constexpr unsigned mantissa_bit_diff =
@@ -74,7 +72,7 @@ struct QFP {
   static_assert(qfp_exponent_bits > 0);
   static_assert(qfp_mantissa_bits > 0);
   static_assert(qfp_total_bits > qfp_exponent_bits);
-  
+
   //
   // convert from a 32-bit float to a QFP
   //
@@ -82,8 +80,7 @@ struct QFP {
     // use the float cast to get the parts of the FP32
     FloatCast f_casted = {.f = f};
     int fp32_sign = f_casted.parts.sign;
-    ac_int<kFP32ExponentBits + 1, true> fp32_exponent =
-        f_casted.parts.exponent;
+    ac_int<kFP32ExponentBits + 1, true> fp32_exponent = f_casted.parts.exponent;
     ac_int<kFP32MantissaBits, false> fp32_mantissa = f_casted.parts.mantissa;
 
     // get the most significant qfp_mantissa_bits from the float's mantissa
@@ -104,10 +101,10 @@ struct QFP {
     if constexpr (is_signed) {
       return qfp_type((qfp_sign << (qfp_exponent_bits + qfp_mantissa_bits)) |
                       (qfp_exponent << qfp_mantissa_bits) | (qfp_mantissa)) &
-                      qfp_mask;
+             qfp_mask;
     } else {
       return qfp_type((qfp_exponent << qfp_mantissa_bits) | (qfp_mantissa)) &
-                      qfp_mask;
+             qfp_mask;
     }
   }
 
@@ -124,14 +121,14 @@ struct QFP {
 
     // get the most significant qfp_mantissa_bits from the float's mantissa
     // NOTE: we are doing truncation here, not rounding.
-    int qfp_mantissa =
-        (fp32_mantissa >> mantissa_bit_diff) & qfp_mantissa_mask;
+    int qfp_mantissa = (fp32_mantissa >> mantissa_bit_diff) & qfp_mantissa_mask;
 
     // compute the QFP exponent. Subtract the FP32 offset (127) from the FP32
     // exponent and add back the QFP exponent offset.
     const int qfp_exponent_tmp =
-        (fp32_exponent == 0) ? 0 :
-        (int(fp32_exponent) - kFP32ExponentOffset + qfp_exponent_offset);
+        (fp32_exponent == 0)
+            ? 0
+            : (int(fp32_exponent) - kFP32ExponentOffset + qfp_exponent_offset);
     int qfp_exponent = (qfp_exponent_tmp < 0) ? 0 : qfp_exponent_tmp;
 
     // get the sign bit
@@ -141,10 +138,10 @@ struct QFP {
     if constexpr (is_signed) {
       return qfp_type((qfp_sign << (qfp_exponent_bits + qfp_mantissa_bits)) |
                       (qfp_exponent << qfp_mantissa_bits) | (qfp_mantissa)) &
-                      qfp_mask;
+             qfp_mask;
     } else {
       return qfp_type((qfp_exponent << qfp_mantissa_bits) | (qfp_mantissa)) &
-                      qfp_mask;
+             qfp_mask;
     }
   }
 
@@ -161,8 +158,8 @@ struct QFP {
         (i >> qfp_mantissa_bits) & qfp_exponent_mask;
     auto fp32_exponent =
         fp32_exponent_tmp - qfp_exponent_offset + kFP32ExponentOffset;
-    ac_int<kFP32MantissaBits, true> fp32_mantissa =
-        (i & qfp_mantissa_mask) << mantissa_bit_diff;
+    ac_int<kFP32MantissaBits, true> fp32_mantissa = (i & qfp_mantissa_mask)
+                                                    << mantissa_bit_diff;
 
     FloatCast f_casted;
     f_casted.parts.sign = sign_bit;
@@ -181,8 +178,7 @@ struct QFP {
     if constexpr (!is_signed) {
       sign_bit = (i >> (qfp_exponent_bits + qfp_mantissa_bits)) & 0x1;
     }
-    int fp32_exponent_tmp =
-        int((i >> qfp_mantissa_bits) & qfp_exponent_mask);
+    int fp32_exponent_tmp = int((i >> qfp_mantissa_bits) & qfp_exponent_mask);
     int fp32_exponent =
         fp32_exponent_tmp - qfp_exponent_offset + kFP32ExponentOffset;
     int fp32_mantissa = (i & qfp_mantissa_mask) << mantissa_bit_diff;
@@ -190,12 +186,11 @@ struct QFP {
     int offset_exponent =
         (fp32_exponent == 0) ? 0 : (fp32_exponent - kFP32ExponentOffset);
     // https://en.wikipedia.org/wiki/Single-precision_floating-point_format
-    //compute the mantissa sum
+    // compute the mantissa sum
     float mantissa_sum = (fp32_exponent == 0) ? 0.0 : 1.0;
     for (int i = 1; i <= kFP32MantissaBits; i++) {
-      mantissa_sum +=
-          ((fp32_mantissa >> (kFP32MantissaBits-i)) & 0x1)
-          * fpga_tools::Pow(2, -i);
+      mantissa_sum += ((fp32_mantissa >> (kFP32MantissaBits - i)) & 0x1) *
+                      fpga_tools::Pow(2, -i);
     }
 
     if (sign_bit == 0)

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/anr/src/qfp_exp_lut.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/anr/src/qfp_exp_lut.hpp
@@ -29,7 +29,7 @@ struct ExpLUT : fpga_tools::ROMBase<unsigned short, kExpLUTDepth> {
   // NOTE: anything called from within the functor's operator() MUST be
   // constexpr or else you won't get a ROM
   struct InitFunctor {
-    constexpr unsigned short operator () (int x) const {
+    constexpr unsigned short operator()(int x) const {
       // treat the ROM index as a QFP number and convert to a float (f) and use
       // the float to compute exp(-f) (== 1/exp(f)) and initialize that entry
       // of the ROM

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/anr/src/qfp_inv_lut.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/anr/src/qfp_inv_lut.hpp
@@ -23,11 +23,11 @@ struct InvLUT : fpga_tools::ROMBase<unsigned short, kInvLutDepth> {
   // NOTE: anything called from within the functor's operator() MUST be
   // constexpr or else you won't get a ROM
   struct InitFunctor {
-    constexpr unsigned short operator () (int x) const {
+    constexpr unsigned short operator()(int x) const {
       // treat the ROM index as a QFP number and convert to a float (f) and use
       // the float to compute 1/f and initialize that entry of the ROM
       float f = QFP::ToFP32CE(x);
-      float val = 1.0f / f ;
+      float val = 1.0f / f;
       return QFP::FromFP32CE(val);
     }
     constexpr InitFunctor() = default;

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/anr/src/row_stencil.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/anr/src/row_stencil.hpp
@@ -1,9 +1,9 @@
 #ifndef __ROW_STENCIL_HPP__
 #define __ROW_STENCIL_HPP__
 
-#include <sycl/sycl.hpp>
-#include <sycl/ext/intel/fpga_extensions.hpp>
 #include <limits>
+#include <sycl/ext/intel/fpga_extensions.hpp>
+#include <sycl/sycl.hpp>
 
 #include "data_bundle.hpp"
 #include "shift_reg.hpp"
@@ -96,19 +96,20 @@ void RowStencil(IndexT rows, IndexT cols, const InType zero_val,
   const IndexT col_loop_bound = padded_cols / parallel_cols;
 
   // the shift register
-  [[intel::fpga_register]]
-  fpga_tools::ShiftReg<InType, kShiftRegSize> shifty_pixels;
+  [[intel::fpga_register]]  // NO-FORMAT: Attribute
+  fpga_tools::ShiftReg<InType, kShiftRegSize>
+      shifty_pixels;
 
-  // initialize the contents of the shift register
-  #pragma unroll
+// initialize the contents of the shift register
+#pragma unroll
   for (int i = 0; i < kShiftRegSize; i++) {
     shifty_pixels[i] = zero_val;
   }
 
   // the main processing loop for the image
-  [[intel::initiation_interval(1)]]
+  [[intel::initiation_interval(1)]]  // NO-FORMAT: Attribute
   for (IndexT row = 0; row < rows; row++) {
-    [[intel::initiation_interval(1)]]
+    [[intel::initiation_interval(1)]]  // NO-FORMAT: Attribute
     for (IndexT col_loop = 0; col_loop < col_loop_bound; col_loop++) {
       IndexT col = col_loop * parallel_cols;
 
@@ -134,7 +135,7 @@ void RowStencil(IndexT rows, IndexT cols, const InType zero_val,
 
         // call the user's callback function for the operator
         out_data[stencil_idx] = func(row, (col_local - kColThreshLow),
-                                      shifty_pixels_copy, stencil_args...);
+                                     shifty_pixels_copy, stencil_args...);
       });
 
       // write the output data if it is in range (i.e., it is a real pixel

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/anr/src/shift_reg.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/anr/src/shift_reg.hpp
@@ -33,32 +33,27 @@ class ShiftReg {
   //        └───┴───┴───┘
   // ```
   void Shift(T &in) {
-    UnrolledLoop<0, (depth - 1)>([&](auto i) {
-      registers_[i] = registers_[i + 1];
-    });
+    UnrolledLoop<0, (depth - 1)>(
+        [&](auto i) { registers_[i] = registers_[i + 1]; });
     registers_[depth - 1] = in;
   }
 
   template <int shift_amt>
   void shiftSingleVal(T &in) {
-    UnrolledLoop<0, (depth - shift_amt)>([&](auto i) {
-      registers_[i] = registers_[i + shift_amt];
-    });
+    UnrolledLoop<0, (depth - shift_amt)>(
+        [&](auto i) { registers_[i] = registers_[i + shift_amt]; });
 
-    UnrolledLoop<(depth - shift_amt), depth>([&](auto i) {
-      registers_[i] = in;
-    });
+    UnrolledLoop<(depth - shift_amt), depth>(
+        [&](auto i) { registers_[i] = in; });
   }
 
   template <int shift_amt>
   void ShiftMultiVals(DataBundle<T, shift_amt> &in) {
-    UnrolledLoop<0, (depth - shift_amt)>([&](auto i) {
-      registers_[i] = registers_[i + shift_amt];
-    });
+    UnrolledLoop<0, (depth - shift_amt)>(
+        [&](auto i) { registers_[i] = registers_[i + shift_amt]; });
 
-    UnrolledLoop<0, shift_amt>([&](auto i) {
-      registers_[(depth - shift_amt) + i] = in[i];
-    });
+    UnrolledLoop<0, shift_amt>(
+        [&](auto i) { registers_[(depth - shift_amt) + i] = in[i]; });
   }
 
   // use an accessor like this to force static accesses
@@ -97,9 +92,8 @@ class ShiftReg2d {
   //        | ^- | <- | <- | <- input i=2
   //        +----+----+----+
   void Shift(T &in) {
-    UnrolledLoop<0, (rows - 1)>([&](auto i) {
-      registers_[i].Shift(registers_[i + 1][0]);
-    });
+    UnrolledLoop<0, (rows - 1)>(
+        [&](auto i) { registers_[i].Shift(registers_[i + 1][0]); });
     registers_[(rows - 1)].Shift(in);
   }
 
@@ -114,9 +108,7 @@ class ShiftReg2d {
   //      ◄─ r ◄ e ◄ g ◄─
   //       └───┴───┴───┘
   void ShiftCol(T in[rows]) {
-    UnrolledLoop<0, rows>([&](auto i) {
-      registers_[i].Shift(in[i]);
-    });
+    UnrolledLoop<0, rows>([&](auto i) { registers_[i].Shift(in[i]); });
   }
 
   template <int shift_amt>


### PR DESCRIPTION
# Existing Sample Changes
## Description

Clang-formats the files from ANR. Added the `no-format` tag for attributes as usual.

Fixes Issue# 

Sample not properly clang-formatted.

## External Dependencies

N/A

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Compiles to reports, as a sanity check.

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
