### PR TITLE
Working coalesce

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_coalesce/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_coalesce/README.md
@@ -199,7 +199,7 @@ If the innermost coalesced loop has a very small trip count, `loop_coalesce` mig
 ## Read the Reports
 Locate `report.html` in the `loop_coalesce_report.prj/reports/` directory. 
 
-On the main report page, scroll down to the section titled `Compile Estimated Kernel Resource Utilization Summary`. Each kernel name ends in the `loop_coalesce` attribute argument used for that kernel, for example, KernelCompute<2> uses a `loop_coalesce` argument of 2. You can verify that the resource consumption for each kernel decreases after nested loops are coalesced.
+On the main report page, scroll down to the section titled `Compile Estimated Kernel Resource Utilization Summary`. Each kernel name ends in the `loop_coalesce` attribute argument used for that kernel; for example, KernelCompute<2> uses a `loop_coalesce` argument of 2. You can verify that the resource consumption for each kernel decreases after nested loops are coalesced due to the significant drop in MLAB utilization. 
 
 ## Run the `Loop Coalesce` Sample
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_coalesce/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_coalesce/README.md
@@ -199,7 +199,7 @@ If the innermost coalesced loop has a very small trip count, `loop_coalesce` mig
 ## Read the Reports
 Locate `report.html` in the `loop_coalesce_report.prj/reports/` directory. 
 
-On the main report page, scroll down to the section titled `Compile Estimated Kernel Resource Utilization Summary`. Each kernel name ends in the `loop_coalesce` attribute argument used for that kernel; for example, KernelCompute<2> uses a `loop_coalesce` argument of 2. You can verify that the number of ALMs used decreases when loops are coalesced. Since KernelCompute<2> has fewer loops than KernelCompute<1>, it requires less hardware for loop overhead. 
+On the main report page, scroll down to the section titled `Compile Estimated Kernel Resource Utilization Summary`. Each kernel name ends in the `loop_coalesce` attribute argument used for that kernel; for example, KernelCompute<2> uses a `loop_coalesce` argument of `2`. You can verify that the number of ALMs used decreases when the loops are coalesced. Since KernelCompute<2> has fewer loops than KernelCompute<1>, it requires less hardware for loop overhead. 
 
 ## Run the `Loop Coalesce` Sample
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_coalesce/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_coalesce/README.md
@@ -199,7 +199,7 @@ If the innermost coalesced loop has a very small trip count, `loop_coalesce` mig
 ## Read the Reports
 Locate `report.html` in the `loop_coalesce_report.prj/reports/` directory. 
 
-On the main report page, scroll down to the section titled `Compile Estimated Kernel Resource Utilization Summary`. Each kernel name ends in the `loop_coalesce` attribute argument used for that kernel; for example, KernelCompute<2> uses a `loop_coalesce` argument of 2. You can verify that the resource consumption for each kernel decreases after nested loops are coalesced due to the significant drop in MLAB utilization. 
+On the main report page, scroll down to the section titled `Compile Estimated Kernel Resource Utilization Summary`. Each kernel name ends in the `loop_coalesce` attribute argument used for that kernel; for example, KernelCompute<2> uses a `loop_coalesce` argument of 2. You can verify that the number of ALMs used decreases when loops are coalesced. 
 
 ## Run the `Loop Coalesce` Sample
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_coalesce/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_coalesce/README.md
@@ -199,7 +199,7 @@ If the innermost coalesced loop has a very small trip count, `loop_coalesce` mig
 ## Read the Reports
 Locate `report.html` in the `loop_coalesce_report.prj/reports/` directory. 
 
-On the main report page, scroll down to the section titled `Compile Estimated Kernel Resource Utilization Summary`. Each kernel name ends in the `loop_coalesce` attribute argument used for that kernel; for example, KernelCompute<2> uses a `loop_coalesce` argument of 2. You can verify that the number of ALMs used decreases when loops are coalesced. 
+On the main report page, scroll down to the section titled `Compile Estimated Kernel Resource Utilization Summary`. Each kernel name ends in the `loop_coalesce` attribute argument used for that kernel; for example, KernelCompute<2> uses a `loop_coalesce` argument of 2. You can verify that the number of ALMs used decreases when loops are coalesced. Since KernelCompute<2> has fewer loops than KernelCompute<1>, less hardware for loop overhead is needed. 
 
 ## Run the `Loop Coalesce` Sample
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_coalesce/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_coalesce/README.md
@@ -199,7 +199,7 @@ If the innermost coalesced loop has a very small trip count, `loop_coalesce` mig
 ## Read the Reports
 Locate `report.html` in the `loop_coalesce_report.prj/reports/` directory. 
 
-On the main report page, scroll down to the section titled `Compile Estimated Kernel Resource Utilization Summary`. Each kernel name ends in the `loop_coalesce` attribute argument used for that kernel; for example, KernelCompute<2> uses a `loop_coalesce` argument of 2. You can verify that the number of ALMs used decreases when loops are coalesced. Since KernelCompute<2> has fewer loops than KernelCompute<1>, less hardware for loop overhead is needed. 
+On the main report page, scroll down to the section titled `Compile Estimated Kernel Resource Utilization Summary`. Each kernel name ends in the `loop_coalesce` attribute argument used for that kernel; for example, KernelCompute<2> uses a `loop_coalesce` argument of 2. You can verify that the number of ALMs used decreases when loops are coalesced. Since KernelCompute<2> has fewer loops than KernelCompute<1>, it requires less hardware for loop overhead. 
 
 ## Run the `Loop Coalesce` Sample
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_coalesce/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_coalesce/README.md
@@ -199,7 +199,7 @@ If the innermost coalesced loop has a very small trip count, `loop_coalesce` mig
 ## Read the Reports
 Locate `report.html` in the `loop_coalesce_report.prj/reports/` directory. 
 
-On the main report page, scroll down to the section titled `Compile Estimated Kernel Resource Utilization Summary`. Each kernel name ends in the `loop_coalesce` attribute argument used for that kernel, for example, KernelCompute<2> uses a `loop_coalesce` argument of 2. You can verify that the number of registers, MLABs, and DSPs used for each kernel decreases after nested loops are coalesced.
+On the main report page, scroll down to the section titled `Compile Estimated Kernel Resource Utilization Summary`. Each kernel name ends in the `loop_coalesce` attribute argument used for that kernel, for example, KernelCompute<2> uses a `loop_coalesce` argument of 2. You can verify that the resource consumption for each kernel decreases after nested loops are coalesced.
 
 ## Run the `Loop Coalesce` Sample
 
@@ -234,21 +234,6 @@ On the main report page, scroll down to the section titled `Compile Estimated Ke
    ```
    loop_coalesce.fpga.exe
    ```
-
-## Example Output
-
-The output displays the execution time and throughput for each kernel. The emulator will not reflect performance differences generally.
-
-```
-Loop Coalesce: 1 -- kernel time : 156 microseconds
-Throughput for kernel with coalesce_factor 1: 6550KB/S
-Loop Coalesce: 2 -- kernel time : 113 microseconds
-Throughput for kernel with coalesce_factor 2: 9064KB/S
-PASSED: The results are correct
-
-```
-
-Applying the `loop_coalesce` attribute in this example reduced the kernel execution time by a factor of ~1.5. **You will only see this result when executing on FPGA hardware.**
 
 ## License
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_coalesce/src/loop_coalesce.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_coalesce/src/loop_coalesce.cpp
@@ -13,8 +13,8 @@
 using namespace sycl;
 
 // Matrix dimensions
-constexpr size_t kNumRows = 100000;
-constexpr size_t kNumCols = 10;
+constexpr size_t kNumRows = 1000;
+constexpr size_t kNumCols = 2;
 constexpr size_t kNumElements = kNumRows * kNumCols;
 
 // Total floating point ops performed by the kernel

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_coalesce/src/loop_coalesce.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_coalesce/src/loop_coalesce.cpp
@@ -13,7 +13,7 @@
 using namespace sycl;
 
 // Matrix dimensions
-constexpr size_t kNumRows = 1000;
+constexpr size_t kNumRows = 500;
 constexpr size_t kNumCols = 2;
 constexpr size_t kNumElements = kNumRows * kNumCols;
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_coalesce/src/loop_coalesce.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_coalesce/src/loop_coalesce.cpp
@@ -13,8 +13,8 @@
 using namespace sycl;
 
 // Matrix dimensions
-constexpr size_t kNumRows = 4;
-constexpr size_t kNumCols = 4;
+constexpr size_t kNumRows = 100000;
+constexpr size_t kNumCols = 10;
 constexpr size_t kNumElements = kNumRows * kNumCols;
 
 // Total floating point ops performed by the kernel


### PR DESCRIPTION
# Existing Sample Changes
## Description

On S10 and Agilex7, the throughput increase described in the README does not appear. In fact, we see a slight decrease in throughput on these boards. I changed the sample to no longer report throughput and have the code sample readme reflect this as well.

I had trouble telling users how to understand the area improvement, since some resources increased and others decreased in such a way that a net improvement resulted. Let me know if you can think of a way I can be more explicit about the area savings.

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used